### PR TITLE
Use `renv::dependencies()` in Colophon

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,9 @@ Imports:
     DT,
     htmltools,
     glue,
-    xfun
+    xfun,
+    renv
 Remotes:  
     rstudio/gt,
-    ropensci/genderdata
+    ropensci/genderdata,
+    rstudio/renv@46f1123

--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ This bookdown book is a *work in progress*. We'll update this `README` and the r
     
 ## Required packages
 
+<!--TODO: Change pkg_list to not be static, maybe use renv::dependencies(path = "DESCRIPTION")?-->
+
 ```{r eval = FALSE}
 pkg_list <- c("bookdown", "devtools", "dichromat", "DT", "fs", "gapminder",
               "gender", "geonames", "git2r", "glue", "gridExtra",  "htmltools",
               "httr", "knitr", "RColorBrewer", "rebird", "rmarkdown", "rplos", 
               "rvest", "testthat", "tidyverse", "usethis", "viridis", "xfun", 
-              "xml2", "ropensci/genderdata", "rstudio/gt")
+              "xml2", "ropensci/genderdata", "rstudio/gt", "rstudio/renv@46f1123")
 ```
 
 Here's one way to install the needed packages (only the ones that you don't already have) using the [`pak` package](https://pak.r-lib.org/index.html).

--- a/index.Rmd
+++ b/index.Rmd
@@ -91,7 +91,11 @@ This book was written in [bookdown](http://bookdown.org/) inside [RStudio](http:
 This version of the book was built with:
 
 ```{r message = FALSE, warning = FALSE, echo = FALSE}
-session <- devtools::session_info()
+# needed because new_session is set to true in _bookdown.yml
+all_pkgs <- renv::dependencies(path = "DESCRIPTION") %>% 
+  pull(Package) 
+
+session <- devtools::session_info(pkgs = all_pkgs)
 
 session$platform
 ```


### PR DESCRIPTION
Use `renv::dependencies()` to get packages used to build book