### PR TITLE
Add gt table of deprecated STAT 545 content

### DIFF
--- a/11_character-vectors.Rmd
+++ b/11_character-vectors.Rmd
@@ -44,8 +44,8 @@ A God-awful and powerful language for expressing patterns to match in text or fo
   - Results come back in a form that is much friendlier for downstream work.
 * The [Strings chapter][r4ds-strings] of [R for Data Science][r4ds] [@wickham2016] is a great resource.
 * Older STAT 545 lessons on regular expressions have some excellent content. This lesson draws on them, but makes more rigorous use of `stringr` and uses example data that is easier to support long-term.
-  -  [2014 Intro to regular expressions](#regex1) by TA Gloria Li.
-  - [2015 Regular expressions and character data in R](#regex2) by TA Kieran Samuk.
+  - [2014 Intro to regular expressions](#oldies) by TA Gloria Li (Appendix \@ref(oldies)).
+  - [2015 Regular expressions and character data in R](#oldies) by TA Kieran Samuk (Appendix \@ref(oldies)).
 * RStudio Cheat Sheet on [Regular Expressions in R][rstudio-regex-cheatsheet].
 * Regex testers:
   - [regex101.com][regex101]
@@ -64,7 +64,7 @@ A God-awful and powerful language for expressing patterns to match in text or fo
 ### Character vectors that live in a data frame
 
 * Certain operations are facilitated by `tidyr`. These are described below.
-* For a general discussion of how to work on variables that live in a data frame, see Appendix \@ref(vectors-tibbles).
+* For a general discussion of how to work on variables that live in a data frame, see [Vectors versus tibbles](#oldies) (Appendix \@ref(oldies)).
 
 ## Load the `tidyverse`, which includes `stringr`
 
@@ -269,7 +269,7 @@ str_subset(fruit, pattern = "\\Bmelon")
 
 ### Character classes
 
-Characters can be specified via classes. You can make them explicitly "by hand" or use some pre-existing ones.  The [2014 STAT 545 regex lesson](#regex1) has a good list of character classes. Character classes are usually given inside square brackets, `[]` but a few come up so often that we have a metacharacter for them, such as `\d` for a single digit.
+Characters can be specified via classes. You can make them explicitly "by hand" or use some pre-existing ones.  The [2014 STAT 545 regex lesson](#oldies) (Appendix \@ref(oldies)) has a good list of character classes. Character classes are usually given inside square brackets, `[]` but a few come up so often that we have a metacharacter for them, such as `\d` for a single digit.
 
 Here we match `ia` at the end of the country name, preceded by one of the characters in the class. Or, in the negated class, preceded by anything but one of those characters.
 
@@ -390,7 +390,7 @@ You can use parentheses inside regexes to define *groups* and you can refer to t
 
 For now, this lesson will refer you to other place to read up on this:
 
-* STAT 545 [2014 Intro to regular expressions](#regex1) by TA Gloria Li.
+* STAT 545 [2014 Intro to regular expressions](#oldies) by TA Gloria Li (Appendix \@ref(oldies)).
 * The [Strings chapter][r4ds-strings] of [R for Data Science][r4ds] [@wickham2016].
 
 ```{r links, child="links.md"}

--- a/21_functions-practicum.Rmd
+++ b/21_functions-practicum.Rmd
@@ -122,7 +122,7 @@ le_lin_fit(gapminder %>% filter(country == "Zimbabwe"))
 
 Yes.
 
-Given how I plan to use this function, I don't feel the need to put it under formal unit tests or put in argument validity checks. Let's move on to [the exciting part](#dplyr-do), which is scaling this up to __all__ countries.
+Given how I plan to use this function, I don't feel the need to put it under formal unit tests or put in argument validity checks. 
 
 
 ```{r links, child="links.md"}

--- a/30_package-overview.Rmd
+++ b/30_package-overview.Rmd
@@ -8,7 +8,7 @@ source("common.R")
 
 <!--Original content: https://stat545.com/packages00_index.html-->
 
-* Chapter \@ref(first-package) - Writing your first R package slides
+* Chapter \@ref(package-slides) - Writing your first R package slides
   + What is an R package?
   + What is a library?
   + Why make an R package?

--- a/39_appendix.Rmd
+++ b/39_appendix.Rmd
@@ -6,52 +6,37 @@
 source("common.R")
 ```
 
-## Vectors versus tibbles {#vectors-tibbles}
+```{r echo = FALSE, message = FALSE, warning = FALSE}
+library(gt)
+library(glue)
+library(readr)
+library(dplyr)
 
-See <https://STAT545-UBC.github.io/STAT545-UBC.github.io/block031_vector-tibble-relations.html> ([Raw](https://github.com/STAT545-UBC/STAT545-UBC.github.io/blob/98ca77ce155b2dbc3878b33635ddebd867041e4c/block031_vector-tibble-relations.Rmd)). *Last updated 10/2016*.
+oldies_urls <- read_csv("admin/deprecated_stat545_urls.csv") 
+base_url <- "https://STAT545-UBC.github.io/STAT545-UBC.github.io"
 
-## Computing by groups within data.frames with `dplyr` and `broom` {#dplyr-do}
-
-See <https://STAT545-UBC.github.io/STAT545-UBC.github.io/block023_dplyr-do.html> ([Raw](https://github.com/STAT545-UBC/STAT545-UBC.github.io/blob/98ca77ce155b2dbc3878b33635ddebd867041e4c/block023_dplyr-do.rmd)). *Last updated 10/2016*.
-
-## Be the boss of your factors (2015)
-
-See <https://STAT545-UBC.github.io/STAT545-UBC.github.io/block014_factors.html>
-([Raw](https://github.com/STAT545-UBC/STAT545-UBC.github.io/blob/98ca77ce155b2dbc3878b33635ddebd867041e4c/block014_factors.rmd)). *Last updated 10/2016*.
-
-
-## Regular expressions and character data {#regex2}
-
-See <https://STAT545-UBC.github.io/STAT545-UBC.github.io/block027_regular-expressions.html> ([Raw](https://github.com/STAT545-UBC/STAT545-UBC.github.io/blob/98ca77ce155b2dbc3878b33635ddebd867041e4c/block027_regular-expressions.Rmd)). *Last updated 11/2015*.
+oldies_formatted <- oldies_urls %>% 
+  mutate(url = glue("{base_url}/{stat545_path}"),
+         md_formatted = glue("[{title}]({url})") %>% md()) %>% 
+  select(md_formatted, last_updated)
 
 
-## Write your own R package, part 1 (2014)
-
-See <https://STAT545-UBC.github.io/STAT545-UBC.github.io/packages02_activity.html>
-([Raw](https://github.com/STAT545-UBC/STAT545-UBC.github.io/blob/98ca77ce155b2dbc3878b33635ddebd867041e4c/packages02_activity.md)). *Last updated 11/2015*.
-
-
-## Write your own R package, part 2 (2014)
-
-See <https://STAT545-UBC.github.io/STAT545-UBC.github.io/packages03_activity_part2.html>
-([Raw](https://github.com/STAT545-UBC/STAT545-UBC.github.io/blob/98ca77ce155b2dbc3878b33635ddebd867041e4c/packages03_activity_part2.md)). *Last updated 11/2015*.
-
-
-## Computing by groups within data.frames with `plyr` {#plyr-ddply}
-
-See <https://STAT545-UBC.github.io/STAT545-UBC.github.io/block013_plyr-ddply.html> ([Raw](https://github.com/STAT545-UBC/STAT545-UBC.github.io/blob/98ca77ce155b2dbc3878b33635ddebd867041e4c/block013_plyr-ddply.rmd)). *Last updated 10/2015*.
-
-
-## Wrapping lm
-
-See <https://STAT545-UBC.github.io/STAT545-UBC.github.io/block025_lm-poly.html>
-([Raw](https://github.com/STAT545-UBC/STAT545-UBC.github.io/blob/98ca77ce155b2dbc3878b33635ddebd867041e4c/block025_lm-poly.rmd)). *Last updated 10/2015*.
-
-
-## Regular expressions in R {#regex1}
-
-See <https://STAT545-UBC.github.io/STAT545-UBC.github.io/block022_regular-expression.html> ([Raw](https://github.com/STAT545-UBC/STAT545-UBC.github.io/blob/98ca77ce155b2dbc3878b33635ddebd867041e4c/block022_regular-expression.rmd)). *Last updated 09/2015*.
-
+oldies_formatted %>% 
+  gt() %>% 
+  tab_header(
+    title = "Deprecated STAT 545 Content"
+  ) %>% 
+  fmt_markdown(
+    columns = TRUE
+    ) %>% 
+  cols_label(
+    md_formatted = "Lesson", 
+    last_updated = "Last Updated"
+  ) %>% 
+  cols_align(
+    align = "left"
+  )
+```
 
 # Short random things {#random}
 

--- a/admin/README.md
+++ b/admin/README.md
@@ -30,4 +30,6 @@ The redirects will be done by Netlify using the `_redirects` file (see Netlify d
 * Specified HTTP status code 301 for redirects from old stat545 content  to the stat545 github.io placeholder (i.e. pages that were *not* moved over to the bookdown site). 
 * Don't have to explicitly tell Netlify to redirect missing pages to a 404. Tested in a practice bookdown and if you add a 404.html file to the dir that Netlify publishes, Netlify will automatically recognize the 404.html and redirect any pages that don't exist there. 
   
-  
+# Deprecated STAT 545 Content
+
+`admin/make-deprecated-csv.R` creates a tibble with info for the deprecated STAT 545 content listed on the previous `https://stat545.com/topics.html` under "Deprecated material that I no longer use. But last I checked, it’s not actually *wrong*" (-JB). This script creates `admin/deprecated_stat545_urls.csv`, which contains the titles, locations (relative url paths), and year last updated for these pages. This csv is used in the Deprecated section of the Appendix to create a table using the `gt` package.

--- a/admin/deprecated_stat545_urls.csv
+++ b/admin/deprecated_stat545_urls.csv
@@ -1,0 +1,10 @@
+title,stat545_path,last_updated
+Vectors versus tibbles,block031_vector-tibble-relations.html,2016
+Computing by groups within data.frames with dplyr and broom,block023_dplyr-do.html,2016
+Be the boss of your factors (2015),block014_factors.html,2016
+Regular expressions and character data (2015),block027_regular-expressions.html,2015
+"Write your own R package, part 1 (2014)",packages02_activity.html,2015
+"Write your own R package, part 2 (2014)",packages03_activity_part2.html,2015
+Computing by groups within data.frames with plyr,block013_plyr-ddply.html,2015
+Wrapping lm,block025_lm-poly.html,2015
+Regular expressions in R (2014),block022_regular-expression.html,2015

--- a/admin/make-deprecated-csv.R
+++ b/admin/make-deprecated-csv.R
@@ -1,0 +1,22 @@
+# Creates a csv file with the title, url path, and year last updated for 
+# all deprecated content. Used in the Appendix to create a gt table. 
+
+library(readr)
+library(dplyr)
+
+deprecated <- tribble(
+  ~title, ~stat545_path, ~last_updated,
+  "Vectors versus tibbles", "block031_vector-tibble-relations.html", "2016",
+  "Computing by groups within data.frames with dplyr and broom", "block023_dplyr-do.html", "2016",
+  "Be the boss of your factors (2015)", "block014_factors.html", "2016",
+  "Regular expressions and character data (2015)", "block027_regular-expressions.html", "2015", 
+  "Write your own R package, part 1 (2014)", "packages02_activity.html", "2015",
+  "Write your own R package, part 2 (2014)", "packages03_activity_part2.html", "2015",
+  "Computing by groups within data.frames with plyr", "block013_plyr-ddply.html", "2015",
+  "Wrapping lm", "block025_lm-poly.html", "2015",
+  "Regular expressions in R (2014)", "block022_regular-expression.html", "2015"
+  
+)
+
+write_csv(deprecated, "admin/deprecated_stat545_urls.csv")
+


### PR DESCRIPTION
To resolve #18 --  

- Adds script in admin to create a csv of links/info for the deprecated STAT 545 pages
- Changes the deprecated section of the Appendix to use a `gt` table for the links instead (see the deploy preview [here](https://5d7820792febd301809048dd--stat545-book.netlify.com/oldies.html))
- Updates any affected cross references
- Fixes one broken cross reference
- Removes the last sentence in `21_functions-practicum.Rmd` that references a deprecated page